### PR TITLE
Index mixin and add tests

### DIFF
--- a/lib/ruby_zen/class_object.rb
+++ b/lib/ruby_zen/class_object.rb
@@ -1,7 +1,8 @@
 module RubyZen
   class ClassObject
     attr_reader :name, :fullname, :is_singleton, :is_module,
-                :superclass, :singleton_class, :namespace
+                :superclass, :singleton_class, :namespace,
+                :included_modules, :extended_modules, :prepended_modules
 
 
     def initialize(fullname, is_module: false, is_singleton: false, superclass: nil, namespace: nil)
@@ -13,6 +14,9 @@ module RubyZen
       @superclass = superclass
       @namespace = namespace
       @method_objects = {}
+      @included_modules = {}
+      @extended_modules = {}
+      @prepended_modules = {}
 
       unless is_singleton
         @singleton_class = RubyZen::ClassObject.new(
@@ -35,6 +39,22 @@ module RubyZen
       end
     end
 
+    def available_instance_methods
+      methods = superclass.available_instance_methods unless superclass.nil?
+
+      @included_modules.each do |included_module|
+        methods.merge!(included_module.available_instance_methods)
+      end
+
+      methods.merge!(@method_objects)
+
+      @prepended_modules.each do |prepended_module|
+        methods.merge!(prepended_module.available_instance_methods)
+      end
+
+      methods
+    end
+
     def class_method_object(method_id)
       return nil if singleton_class.nil?
       singleton_class.instance_method_object(method_id)
@@ -51,6 +71,18 @@ module RubyZen
 
     def add_class_method(method_object)
       singleton_class.add_method(method_object) unless singleton_class.nil?
+    end
+
+    def include_module(module_definition)
+      @included_modules[module_definition.name] = module_definition
+    end
+
+    def extend_module(module_definition)
+      @extended_modules[module_definition.name] = module_definition
+    end
+
+    def prepend_module(module_definition)
+      @prepended_modules[module_definition.name] = module_definition
     end
 
     def inspect

--- a/lib/ruby_zen/class_object.rb
+++ b/lib/ruby_zen/class_object.rb
@@ -2,15 +2,14 @@ module RubyZen
   class ClassObject
     attr_reader :name, :fullname, :is_singleton, :singleton_class,
                 :included_modules, :extended_modules, :prepended_modules
-    attr_accessor :is_defined, :is_module, :superclass, :namespace
+    attr_accessor :is_module, :superclass, :namespace
 
-    def initialize(fullname, is_module: false, is_singleton: false, superclass: nil, namespace: nil, is_defined: true)
+    def initialize(fullname, is_module: false, is_singleton: false, superclass: nil, namespace: nil)
       @fullname = fullname.to_s
       @name = @fullname.split('::').last
 
       @is_module = is_module
       @is_singleton = is_singleton
-      @is_defined = is_defined
       @superclass = superclass
       @namespace = namespace
       @method_objects = {}
@@ -40,7 +39,6 @@ module RubyZen
     end
 
     def available_instance_methods
-      return {} unless is_defined
       methods = superclass.nil? ? {} : superclass.available_instance_methods
 
       @included_modules.each do |_module_name, module_definition|
@@ -57,7 +55,6 @@ module RubyZen
     end
 
     def available_class_methods(as_module = false)
-      return {} unless is_defined
       methods = superclass.nil? ? {} : superclass.available_class_methods
 
       if is_module && !as_module
@@ -99,18 +96,6 @@ module RubyZen
 
     def prepend_module(module_definition)
       @prepended_modules[module_definition.name] = module_definition
-    end
-
-    def update_module(namespace)
-      self.is_defined = true
-      self.is_module = true
-      self.namespace = namespace
-    end
-
-    def update_class(namespace, superclass)
-      self.is_defined = true
-      self.namespace = namespace
-      self.superclass = superclass
     end
 
     def inspect

--- a/lib/ruby_zen/engine.rb
+++ b/lib/ruby_zen/engine.rb
@@ -41,7 +41,7 @@ module RubyZen
 
     def define_class(class_name)
       class_name = class_name.to_s
-      if @classes[class_name]
+      if @classes[class_name] && @classes[class_name].is_defined
         @classes[class_name]
       elsif block_given?
         @classes[class_name] = yield

--- a/lib/ruby_zen/engine.rb
+++ b/lib/ruby_zen/engine.rb
@@ -41,12 +41,18 @@ module RubyZen
 
     def define_class(class_name)
       class_name = class_name.to_s
-      if @classes[class_name] && @classes[class_name].is_defined
-        @classes[class_name]
-      elsif block_given?
-        @classes[class_name] = yield
+      return @classes[class_name] unless block_given?
+
+      class_object = yield
+      if @classes[class_name]
+        # Finalize class object type
+        @classes[class_name].tap do |old_object|
+          old_object.is_module = class_object.is_module
+          old_object.namespace = class_object.namespace
+          old_object.superclass = class_object.superclass
+        end
       else
-        raise 'This method requires a block'
+        @classes[class_name] = class_object
       end
     end
 

--- a/lib/ruby_zen/indexers/iseq_indexer.rb
+++ b/lib/ruby_zen/indexers/iseq_indexer.rb
@@ -63,6 +63,18 @@ module RubyZen::Indexers
         receiver.class_method_object(method_name)
       end
 
+      @vm.register_processor('opt_send_without_block', 'include') do |receiver, module_definition|
+        receiver.include_module(module_definition)
+      end
+
+      @vm.register_processor('opt_send_without_block', 'extend') do |receiver, module_definition|
+        receiver.extend_module(module_definition)
+      end
+
+      @vm.register_processor('opt_send_without_block', 'prepend') do |receiver, module_definition|
+        receiver.prepend_module(module_definition)
+      end
+
       @vm.register_processor('send', 'define_method') do |receiver, method_name, method_body|
         define_instance_method(receiver, method_name, method_body)
       end

--- a/lib/ruby_zen/indexers/iseq_indexer.rb
+++ b/lib/ruby_zen/indexers/iseq_indexer.rb
@@ -40,7 +40,7 @@ module RubyZen::Indexers
         const = @engine.fetch_class(name)
         if const.nil?
           @engine.define_class(name) do
-            RubyZen::ClassObject.new(name)
+            RubyZen::ClassObject.new(name, is_module: true)
           end
         else
           const

--- a/lib/ruby_zen/indexers/iseq_indexer.rb
+++ b/lib/ruby_zen/indexers/iseq_indexer.rb
@@ -17,26 +17,16 @@ module RubyZen::Indexers
     def register_processors
       @vm.register_processor('defineclass') do |name, _body, superclass, cbase, flags|
         name = "#{cbase.fullname}::#{name}" unless cbase.nil?
-        klass = @engine.fetch_class(name)
         if (flags & 0x1) > 0
           # Singleton class
           cbase.singleton_class
         elsif (flags & 0x2) > 0
           # Module
-          if klass
-            klass.update_module(cbase)
-            klass
-          else
-            @engine.define_class(name) do
-              RubyZen::ClassObject.new(
-                name, is_module: true, namespace: cbase
-              )
-            end
+          @engine.define_class(name) do
+            RubyZen::ClassObject.new(
+              name, is_module: true, namespace: cbase
+            )
           end
-        elsif klass
-          # Normal class
-          klass.update_class(cbase, superclass)
-          klass
         else
           # Normal class
           @engine.define_class(name) do
@@ -50,7 +40,7 @@ module RubyZen::Indexers
         const = @engine.fetch_class(name)
         if const.nil?
           @engine.define_class(name) do
-            RubyZen::ClassObject.new(name, is_defined: false)
+            RubyZen::ClassObject.new(name)
           end
         else
           const

--- a/lib/ruby_zen/vm.rb
+++ b/lib/ruby_zen/vm.rb
@@ -165,6 +165,33 @@ module RubyZen
           args: [receiver, method_name]
         )
         @stack.push(method_object)
+      when :include
+        module_definition = @stack.pop
+        receiver = @stack.pop
+
+        dispatch_processor(
+          instruction.name,
+          filter: 'include',
+          args: [receiver, module_definition]
+        )
+      when :extend
+        module_definition = @stack.pop
+        receiver = @stack.pop
+
+        dispatch_processor(
+          instruction.name,
+          filter: 'extend',
+          args: [receiver, module_definition]
+        )
+      when :prepend
+        module_definition = @stack.pop
+        receiver = @stack.pop
+
+        dispatch_processor(
+          instruction.name,
+          filter: 'prepend',
+          args: [receiver, module_definition]
+        )
       else
         @logger.debug("Method #{call_info.mid} not handled.")
       end

--- a/spec/definitions/mixin_spec.rb
+++ b/spec/definitions/mixin_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+RSpec.describe 'index mixin-ed class' do
+  let(:class_name) { 'Man' }
+  let(:include_module) { 'UpOnTheSky' }
+  let(:extend_module) { 'UnderTheSea' }
+  let(:prepend_module) { 'OnTheGround' }
+  let(:code) do
+    <<-CODE
+      class Man
+        include UpOnTheSky
+        extend UnderTheSea
+        prepend OnTheGround
+      end
+
+      module UpOnTheSky
+        def soar
+          "soaring..."
+        end
+      end
+
+      module UnderTheSea
+        def dive
+          "diving..."
+        end
+      end
+
+      module OnTheGround
+        def run
+          "running..."
+        end
+      end
+    CODE
+  end
+
+  let(:engine) { RubyZen::Engine.new(logger: TestingLogger.new(STDOUT)) }
+  let(:iseq) { YarvGenerator.build_from_source(code) }
+
+  before do
+    engine.index_iseq(iseq)
+  end
+
+  it 'indexes included modules' do
+    defined_module = engine.fetch_class(include_module)
+    included_modules = engine.fetch_class(class_name).included_modules
+    expect(included_modules[include_module]).to eql(defined_module)
+  end
+
+  it 'indexes extended modules' do
+    defined_module = engine.fetch_class(extend_module)
+    extended_modules = engine.fetch_class(class_name).extended_modules
+    expect(extended_modules[extend_module]).to eql(defined_module)
+  end
+
+  it 'indexes prepended modules' do
+    defined_module = engine.fetch_class(prepend_module)
+    prepended_modules = engine.fetch_class(class_name).prepended_modules
+    expect(prepended_modules[prepend_module]).to eql(defined_module)
+  end
+end

--- a/spec/definitions/mixin_spec.rb
+++ b/spec/definitions/mixin_spec.rb
@@ -1,37 +1,9 @@
 require 'spec_helper'
 
 RSpec.describe 'index mixin-ed class' do
-  let(:class_name) { 'Man' }
-  let(:include_module) { 'UpOnTheSky' }
-  let(:extend_module) { 'UnderTheSea' }
-  let(:prepend_module) { 'OnTheGround' }
-  let(:code) do
-    <<-CODE
-      class Man
-        include UpOnTheSky
-        extend UnderTheSea
-        prepend OnTheGround
-      end
-
-      module UpOnTheSky
-        def soar
-          "soaring..."
-        end
-      end
-
-      module UnderTheSea
-        def dive
-          "diving..."
-        end
-      end
-
-      module OnTheGround
-        def run
-          "running..."
-        end
-      end
-    CODE
-  end
+  let(:class_name) { 'SampleClass' }
+  let(:module_1) { 'FirstModule' }
+  let(:module_2) { 'SecondModule' }
 
   let(:engine) { RubyZen::Engine.new(logger: TestingLogger.new(STDOUT)) }
   let(:iseq) { YarvGenerator.build_from_source(code) }
@@ -40,21 +12,561 @@ RSpec.describe 'index mixin-ed class' do
     engine.index_iseq(iseq)
   end
 
-  it 'indexes included modules' do
-    defined_module = engine.fetch_class(include_module)
-    included_modules = engine.fetch_class(class_name).included_modules
-    expect(included_modules[include_module]).to eql(defined_module)
+  context 'include' do
+    let(:code) do
+      <<-CODE
+        class SampleClass
+          include FirstModule
+          include SecondModule
+
+          def self.class_method; end
+
+          def breathe
+           "breathing..."
+          end
+
+          def fly
+            "flying..."
+          end
+        end
+
+        module FirstModule
+          def soar
+            "soaring..."
+          end
+
+          def fly
+            "flying..."
+          end
+
+          def float
+            "floating..."
+          end
+        end
+
+        module SecondModule
+          def SecondModule.module_class_method; end
+
+          def soar
+            "soaring..."
+          end
+        end
+      CODE
+    end
+
+    it 'indexes included module' do
+      indexed_module_one = engine.fetch_class(module_1)
+      indexed_module_two = engine.fetch_class(module_2)
+      included_modules = engine.fetch_class(class_name).included_modules
+
+      expect(included_modules.length).to eq(2)
+      expect(included_modules[module_1]).to eql(indexed_module_one)
+      expect(included_modules[module_2]).to eql(indexed_module_two)
+    end
+
+    it 'returns correct accessible methods' do
+      indexed_module_one = engine.fetch_class(module_1)
+      indexed_module_two = engine.fetch_class(module_2)
+      indexed_class = engine.fetch_class(class_name)
+      instance_methods = indexed_class.available_instance_methods
+
+      expect(instance_methods.length).to eq(4)
+      expect(instance_methods[:breathe].owner).to eq(indexed_class)
+      expect(instance_methods[:fly].owner).to eq(indexed_class)
+      expect(instance_methods[:soar].owner).to eq(indexed_module_two)
+      expect(instance_methods[:float].owner).to eq(indexed_module_one)
+    end
   end
 
-  it 'indexes extended modules' do
-    defined_module = engine.fetch_class(extend_module)
-    extended_modules = engine.fetch_class(class_name).extended_modules
-    expect(extended_modules[extend_module]).to eql(defined_module)
+  context 'extend' do
+    let(:code) do
+      <<-CODE
+        class SampleClass
+          extend FirstModule
+          extend SecondModule
+
+          def self.breathe
+           "breathing..."
+          end
+
+          def SampleClass.fly
+            "flying..."
+          end
+
+          def an_instance_method; end
+        end
+
+        module FirstModule
+          def soar
+            "soaring..."
+          end
+
+          def fly
+            "flying..."
+          end
+
+          def float
+            "floating..."
+          end
+        end
+
+        module SecondModule
+          def SecondModule.module_class_method; end
+
+          def soar
+            "soaring..."
+          end
+        end
+      CODE
+    end
+
+    it 'indexes extended modules' do
+      indexed_module_one = engine.fetch_class(module_1)
+      indexed_module_two = engine.fetch_class(module_2)
+      extended_modules = engine.fetch_class(class_name).extended_modules
+
+      expect(extended_modules.length).to eq(2)
+      expect(extended_modules[module_1]).to eql(indexed_module_one)
+      expect(extended_modules[module_2]).to eql(indexed_module_two)
+    end
+
+    it 'returns correct accessible class methods' do
+      indexed_module_one = engine.fetch_class(module_1)
+      indexed_module_two = engine.fetch_class(module_2)
+      indexed_class = engine.fetch_class(class_name)
+      class_methods = indexed_class.available_class_methods
+
+      expect(class_methods.length).to eq(4)
+      expect(class_methods[:breathe].owner).to eq(indexed_class.singleton_class)
+      expect(class_methods[:fly].owner).to eq(indexed_class.singleton_class)
+      expect(class_methods[:soar].owner).to eq(indexed_module_two)
+      expect(class_methods[:float].owner).to eq(indexed_module_one)
+    end
   end
 
-  it 'indexes prepended modules' do
-    defined_module = engine.fetch_class(prepend_module)
-    prepended_modules = engine.fetch_class(class_name).prepended_modules
-    expect(prepended_modules[prepend_module]).to eql(defined_module)
+  context 'prepend' do
+    let(:code) do
+      <<-CODE
+        class SampleClass
+          prepend FirstModule
+          prepend SecondModule
+
+          def breathe
+           "breathing..."
+          end
+
+          def fly
+            "flying..."
+          end
+
+          def self.class_method; end
+        end
+
+        module FirstModule
+          def soar
+            "soaring..."
+          end
+
+          def fly
+            "flying..."
+          end
+
+          def float
+            "floating..."
+          end
+        end
+
+        module SecondModule
+          def SecondModule.module_class_method; end
+
+          def soar
+            "soaring..."
+          end
+        end
+      CODE
+    end
+
+    it 'indexes prepended modules' do
+      indexed_module_one = engine.fetch_class(module_1)
+      indexed_module_two = engine.fetch_class(module_2)
+      prepended_modules = engine.fetch_class(class_name).prepended_modules
+
+      expect(prepended_modules.length).to eq(2)
+      expect(prepended_modules[module_1]).to eql(indexed_module_one)
+      expect(prepended_modules[module_2]).to eql(indexed_module_two)
+    end
+
+    it 'returns correct accessible instance methods' do
+      indexed_module_one = engine.fetch_class(module_1)
+      indexed_module_two = engine.fetch_class(module_2)
+      indexed_class = engine.fetch_class(class_name)
+      instance_methods = indexed_class.available_instance_methods
+
+      expect(instance_methods.length).to eq(4)
+      expect(instance_methods[:breathe].owner).to eq(indexed_class)
+      expect(instance_methods[:fly].owner).to eq(indexed_module_one)
+      expect(instance_methods[:soar].owner).to eq(indexed_module_two)
+      expect(instance_methods[:float].owner).to eq(indexed_module_one)
+    end
+  end
+
+  context 'mixin with include and prepend' do
+    let(:code) do
+      <<-CODE
+        class SampleClass
+          include FirstModule
+          prepend SecondModule
+
+          def breathe
+           "breathing..."
+          end
+
+          def fly
+            "flying..."
+          end
+
+          def self.class_method; end
+        end
+
+        module FirstModule
+          def soar
+            "soaring..."
+          end
+
+          def fly
+            "flying..."
+          end
+
+          def float
+            "floating..."
+          end
+        end
+
+        module SecondModule
+          def SecondModule.module_class_method; end
+
+          def soar
+            "soaring..."
+          end
+
+          def fly
+            "flying..."
+          end
+        end
+      CODE
+    end
+
+    it 'indexes included and prepended modules' do
+      indexed_module_one = engine.fetch_class(module_1)
+      indexed_module_two = engine.fetch_class(module_2)
+      included_modules = engine.fetch_class(class_name).included_modules
+      prepended_modules = engine.fetch_class(class_name).prepended_modules
+
+      expect(included_modules.length).to eq(1)
+      expect(prepended_modules.length).to eq(1)
+      expect(included_modules[module_1]).to eql(indexed_module_one)
+      expect(prepended_modules[module_2]).to eql(indexed_module_two)
+    end
+
+    it 'returns correct accessible instance methods' do
+      indexed_module_one = engine.fetch_class(module_1)
+      indexed_module_two = engine.fetch_class(module_2)
+      indexed_class = engine.fetch_class(class_name)
+      instance_methods = indexed_class.available_instance_methods
+
+      expect(instance_methods.length).to eq(4)
+      expect(instance_methods[:breathe].owner).to eq(indexed_class)
+      expect(instance_methods[:fly].owner).to eq(indexed_module_two)
+      expect(instance_methods[:soar].owner).to eq(indexed_module_two)
+      expect(instance_methods[:float].owner).to eq(indexed_module_one)
+    end
+  end
+
+  context 'complex mixin' do
+    let(:parent_class) { 'ParentSampleClass'}
+    let(:grandparent_class) { 'GrandparentSampleClass' }
+    let(:module_3) { 'ThirdModule' }
+    let(:indexed_module_one) { engine.fetch_class(module_1) }
+    let(:indexed_module_two) { engine.fetch_class(module_2) }
+    let(:indexed_module_three) { engine.fetch_class(module_3) }
+
+    let(:code) do
+      <<-CODE
+        class SampleClass < ParentSampleClass
+          include FirstModule
+          prepend ThirdModule
+          extend SecondModule
+
+          def breathe
+           "breathing..."
+          end
+
+          def fly
+            "flying..."
+          end
+
+          def self.copy; end
+        end
+
+        module FirstModule
+          def soar
+            "soaring..."
+          end
+
+          def fly
+            "flying..."
+          end
+
+          def float
+            "floating..."
+          end
+        end
+
+        module SecondModule
+          def SecondModule.module_class_method; end
+
+          def soar
+            "soaring..."
+          end
+
+          def fly
+            "flying..."
+          end
+        end
+
+        module ThirdModule
+          include SecondModule
+          prepend FirstModule
+          extend FirstModule
+          extend SecondModule
+
+          def swim
+            "swimming..."
+          end
+
+          def play
+            "playing..."
+          end
+
+          def fly
+            "flying..."
+          end
+        end
+
+        class ParentSampleClass < GrandparentSampleClass
+          include ThirdModule
+          include SecondModule
+
+          def self.stroll(source)
+            puts source
+          end
+
+          class << self
+            def copy(source)
+              puts source
+            end
+
+            define_method(:compare) do |other|
+              puts other
+            end
+            define_method :copy_2, ParentSampleClass.method(:copy)
+            define_method :copy_3, ParentSampleClass.method(:copy).to_proc
+            define_method :copy_4, instance_method(:copy)
+          end
+
+          define_singleton_method(:destroy) do |force|
+            puts a
+          end
+        end
+
+        class GrandparentSampleClass
+          extend SecondModule
+
+          def self.soar
+            "soaring..."
+          end
+
+          def gardening
+           "gardening.."
+          end
+
+          def GrandparentSampleClass.stroll
+            "strolling..."
+          end
+        end
+
+        class << GrandparentSampleClass
+          def build(data)
+            puts data
+          end
+        end
+
+        def GrandparentSampleClass.seal(key)
+          puts key
+        end
+      CODE
+    end
+
+    context 'ThirdModule' do
+      it 'indexes prepended modules' do
+        included_modules = engine.fetch_class(module_3).included_modules
+        extended_modules = engine.fetch_class(module_3).extended_modules
+        prepended_modules = engine.fetch_class(module_3).prepended_modules
+
+        expect(included_modules.length).to eq(1)
+        expect(included_modules[module_2]).to eql(indexed_module_two)
+
+        expect(extended_modules.length).to eq(2)
+        expect(extended_modules[module_1]).to eql(indexed_module_one)
+        expect(extended_modules[module_2]).to eql(indexed_module_two)
+
+        expect(prepended_modules.length).to eq(1)
+        expect(prepended_modules[module_1]).to eql(indexed_module_one)
+      end
+
+      it 'returns correct accessible instance methods' do
+        indexed_module = engine.fetch_class(module_3)
+        instance_methods = indexed_module.available_instance_methods
+
+        expect(instance_methods.length).to eq(5)
+        expect(instance_methods[:soar].owner).to eq(indexed_module_one)
+        expect(instance_methods[:fly].owner).to eq(indexed_module_one)
+        expect(instance_methods[:swim].owner).to eq(indexed_module)
+        expect(instance_methods[:play].owner).to eq(indexed_module)
+        expect(instance_methods[:float].owner).to eq(indexed_module_one)
+      end
+
+      it 'returns correct accessible class method' do
+        indexed_module = engine.fetch_class(module_3)
+        class_methods = indexed_module.available_class_methods(true)
+
+        expect(class_methods.length).to eq(3)
+        expect(class_methods[:soar].owner).to eq(indexed_module_two)
+        expect(class_methods[:fly].owner).to eq(indexed_module_two)
+        expect(class_methods[:float].owner).to eq(indexed_module_one)
+      end
+    end
+
+    context 'GrandparentSampleClass' do
+      it 'indexes extended modules' do
+        extended_modules = engine.fetch_class(grandparent_class).extended_modules
+
+        expect(extended_modules.length).to eq(1)
+        expect(extended_modules[module_2]).to eql(indexed_module_two)
+      end
+
+      it 'returns correct accessible instance method' do
+        indexed_class = engine.fetch_class(grandparent_class)
+        instance_methods = indexed_class.available_instance_methods
+
+        expect(instance_methods.length).to eq(1)
+        expect(instance_methods[:gardening].owner).to eq(indexed_class)
+      end
+
+      it 'returns correct accessible class method' do
+        indexed_class = engine.fetch_class(grandparent_class)
+        class_methods = indexed_class.available_class_methods
+
+        expect(class_methods.length).to eq(5)
+        expect(class_methods[:soar].owner).to eq(indexed_class.singleton_class)
+        expect(class_methods[:fly].owner).to eq(indexed_module_two)
+        expect(class_methods[:stroll].owner).to eq(indexed_class.singleton_class)
+        expect(class_methods[:build].owner).to eq(indexed_class.singleton_class)
+        expect(class_methods[:seal].owner).to eq(indexed_class.singleton_class)
+      end
+    end
+
+    context 'ParentSampleClass' do
+      it 'indexes included modules' do
+        included_modules = engine.fetch_class(parent_class).included_modules
+
+        expect(included_modules.length).to eq(2)
+        expect(included_modules[module_2]).to eq(indexed_module_two)
+        expect(included_modules[module_3]).to eq(indexed_module_three)
+      end
+
+      it 'returns correct accessible instance method' do
+        indexed_class = engine.fetch_class(parent_class)
+        indexed_parent_class = engine.fetch_class(grandparent_class)
+        instance_methods = indexed_class.available_instance_methods
+
+        expect(instance_methods.length).to eq(6)
+        expect(instance_methods[:soar].owner).to eq(indexed_module_two)
+        expect(instance_methods[:fly].owner).to eq(indexed_module_two)
+        expect(instance_methods[:swim].owner).to eq(indexed_module_three)
+        expect(instance_methods[:play].owner).to eq(indexed_module_three)
+        expect(instance_methods[:float].owner).to eq(indexed_module_one)
+        expect(instance_methods[:gardening].owner).to eq(indexed_parent_class)
+      end
+
+      it 'returns correct accessible class method' do
+        indexed_class = engine.fetch_class(parent_class)
+        indexed_parent_class = engine.fetch_class(grandparent_class)
+        class_methods = indexed_class.available_class_methods
+
+        expect(class_methods.length).to eq(11)
+        expect(class_methods[:stroll].owner).to eq(indexed_class.singleton_class)
+        expect(class_methods[:copy].owner).to eq(indexed_class.singleton_class)
+        expect(class_methods[:copy_2].owner).to eq(indexed_class.singleton_class)
+        expect(class_methods[:copy_3].owner).to eq(indexed_class.singleton_class)
+        expect(class_methods[:copy_4].owner).to eq(indexed_class.singleton_class)
+        expect(class_methods[:destroy].owner).to eq(indexed_class.singleton_class)
+        expect(class_methods[:compare].owner).to eq(indexed_class.singleton_class)
+        expect(class_methods[:build].owner).to eq(indexed_parent_class.singleton_class)
+        expect(class_methods[:seal].owner).to eq(indexed_parent_class.singleton_class)
+        expect(class_methods[:soar].owner).to eq(indexed_parent_class.singleton_class)
+        expect(class_methods[:fly].owner).to eq(indexed_module_two)
+      end
+    end
+
+    context 'SampleClass' do
+      it 'indexes included, extended and prepended modules' do
+        included_modules = engine.fetch_class(class_name).included_modules
+        extended_modules = engine.fetch_class(class_name).extended_modules
+        prepended_modules = engine.fetch_class(class_name).prepended_modules
+
+        expect(included_modules.length).to eq(1)
+        expect(extended_modules.length).to eq(1)
+        expect(prepended_modules.length).to eq(1)
+        expect(included_modules[module_1]).to eql(indexed_module_one)
+        expect(extended_modules[module_2]).to eql(indexed_module_two)
+        expect(prepended_modules[module_3]).to eql(indexed_module_three)
+      end
+
+      it 'returns correct accessible instance method' do
+        indexed_class = engine.fetch_class(class_name)
+        indexed_grandparent_class = engine.fetch_class(grandparent_class)
+        instance_methods = indexed_class.available_instance_methods
+
+        expect(instance_methods.length).to eq(7)
+        expect(instance_methods[:breathe].owner).to eq(indexed_class)
+        expect(instance_methods[:soar].owner).to eq(indexed_module_one)
+        expect(instance_methods[:fly].owner).to eq(indexed_module_one)
+        expect(instance_methods[:swim].owner).to eq(indexed_module_three)
+        expect(instance_methods[:play].owner).to eq(indexed_module_three)
+        expect(instance_methods[:float].owner).to eq(indexed_module_one)
+        expect(instance_methods[:gardening].owner).to eq(indexed_grandparent_class)
+      end
+
+      it 'returns correct accessible class method' do
+        indexed_class = engine.fetch_class(class_name)
+        indexed_parent_class = engine.fetch_class(parent_class)
+        indexed_grandparent_class = engine.fetch_class(grandparent_class)
+        class_methods = indexed_class.available_class_methods
+
+        expect(class_methods.length).to eq(11)
+        expect(class_methods[:soar].owner).to eq(indexed_module_two)
+        expect(class_methods[:fly].owner).to eq(indexed_module_two)
+        expect(class_methods[:build].owner).to eq(indexed_grandparent_class.singleton_class)
+        expect(class_methods[:seal].owner).to eq(indexed_grandparent_class.singleton_class)
+        expect(class_methods[:stroll].owner).to eq(indexed_parent_class.singleton_class)
+        expect(class_methods[:copy].owner).to eq(indexed_class.singleton_class)
+        expect(class_methods[:copy_2].owner).to eq(indexed_parent_class.singleton_class)
+        expect(class_methods[:copy_3].owner).to eq(indexed_parent_class.singleton_class)
+        expect(class_methods[:copy_4].owner).to eq(indexed_parent_class.singleton_class)
+        expect(class_methods[:destroy].owner).to eq(indexed_parent_class.singleton_class)
+        expect(class_methods[:compare].owner).to eq(indexed_parent_class.singleton_class)
+      end
+    end
   end
 end

--- a/spec/definitions/mixin_spec.rb
+++ b/spec/definitions/mixin_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe 'index mixin-ed class' do
       indexed_module_one = engine.fetch_class(module_1)
       indexed_module_two = engine.fetch_class(module_2)
       indexed_class = engine.fetch_class(class_name)
-      instance_methods = indexed_class.available_instance_methods
+      instance_methods = indexed_class.instance_method_objects
 
       expect(instance_methods.length).to eq(4)
       expect(instance_methods[:breathe].owner).to eq(indexed_class)
@@ -134,7 +134,7 @@ RSpec.describe 'index mixin-ed class' do
       indexed_module_one = engine.fetch_class(module_1)
       indexed_module_two = engine.fetch_class(module_2)
       indexed_class = engine.fetch_class(class_name)
-      class_methods = indexed_class.available_class_methods
+      class_methods = indexed_class.class_method_objects
 
       expect(class_methods.length).to eq(4)
       expect(class_methods[:breathe].owner).to eq(indexed_class.singleton_class)
@@ -200,7 +200,7 @@ RSpec.describe 'index mixin-ed class' do
       indexed_module_one = engine.fetch_class(module_1)
       indexed_module_two = engine.fetch_class(module_2)
       indexed_class = engine.fetch_class(class_name)
-      instance_methods = indexed_class.available_instance_methods
+      instance_methods = indexed_class.instance_method_objects
 
       expect(instance_methods.length).to eq(4)
       expect(instance_methods[:breathe].owner).to eq(indexed_class)
@@ -272,7 +272,7 @@ RSpec.describe 'index mixin-ed class' do
       indexed_module_one = engine.fetch_class(module_1)
       indexed_module_two = engine.fetch_class(module_2)
       indexed_class = engine.fetch_class(class_name)
-      instance_methods = indexed_class.available_instance_methods
+      instance_methods = indexed_class.instance_method_objects
 
       expect(instance_methods.length).to eq(4)
       expect(instance_methods[:breathe].owner).to eq(indexed_class)
@@ -426,7 +426,7 @@ RSpec.describe 'index mixin-ed class' do
 
       it 'returns correct accessible instance methods' do
         indexed_module = engine.fetch_class(module_3)
-        instance_methods = indexed_module.available_instance_methods
+        instance_methods = indexed_module.instance_method_objects
 
         expect(instance_methods.length).to eq(5)
         expect(instance_methods[:soar].owner).to eq(indexed_module_one)
@@ -438,7 +438,7 @@ RSpec.describe 'index mixin-ed class' do
 
       it 'returns correct accessible class method' do
         indexed_module = engine.fetch_class(module_3)
-        class_methods = indexed_module.available_class_methods(true)
+        class_methods = indexed_module.class_method_objects(true)
 
         expect(class_methods.length).to eq(3)
         expect(class_methods[:soar].owner).to eq(indexed_module_two)
@@ -457,7 +457,7 @@ RSpec.describe 'index mixin-ed class' do
 
       it 'returns correct accessible instance method' do
         indexed_class = engine.fetch_class(grandparent_class)
-        instance_methods = indexed_class.available_instance_methods
+        instance_methods = indexed_class.instance_method_objects
 
         expect(instance_methods.length).to eq(1)
         expect(instance_methods[:gardening].owner).to eq(indexed_class)
@@ -465,7 +465,7 @@ RSpec.describe 'index mixin-ed class' do
 
       it 'returns correct accessible class method' do
         indexed_class = engine.fetch_class(grandparent_class)
-        class_methods = indexed_class.available_class_methods
+        class_methods = indexed_class.class_method_objects
 
         expect(class_methods.length).to eq(5)
         expect(class_methods[:soar].owner).to eq(indexed_class.singleton_class)
@@ -488,7 +488,7 @@ RSpec.describe 'index mixin-ed class' do
       it 'returns correct accessible instance method' do
         indexed_class = engine.fetch_class(parent_class)
         indexed_parent_class = engine.fetch_class(grandparent_class)
-        instance_methods = indexed_class.available_instance_methods
+        instance_methods = indexed_class.instance_method_objects
 
         expect(instance_methods.length).to eq(6)
         expect(instance_methods[:soar].owner).to eq(indexed_module_two)
@@ -502,7 +502,7 @@ RSpec.describe 'index mixin-ed class' do
       it 'returns correct accessible class method' do
         indexed_class = engine.fetch_class(parent_class)
         indexed_parent_class = engine.fetch_class(grandparent_class)
-        class_methods = indexed_class.available_class_methods
+        class_methods = indexed_class.class_method_objects
 
         expect(class_methods.length).to eq(11)
         expect(class_methods[:stroll].owner).to eq(indexed_class.singleton_class)
@@ -536,7 +536,7 @@ RSpec.describe 'index mixin-ed class' do
       it 'returns correct accessible instance method' do
         indexed_class = engine.fetch_class(class_name)
         indexed_grandparent_class = engine.fetch_class(grandparent_class)
-        instance_methods = indexed_class.available_instance_methods
+        instance_methods = indexed_class.instance_method_objects
 
         expect(instance_methods.length).to eq(7)
         expect(instance_methods[:breathe].owner).to eq(indexed_class)
@@ -552,7 +552,7 @@ RSpec.describe 'index mixin-ed class' do
         indexed_class = engine.fetch_class(class_name)
         indexed_parent_class = engine.fetch_class(parent_class)
         indexed_grandparent_class = engine.fetch_class(grandparent_class)
-        class_methods = indexed_class.available_class_methods
+        class_methods = indexed_class.class_method_objects
 
         expect(class_methods.length).to eq(11)
         expect(class_methods[:soar].owner).to eq(indexed_module_two)

--- a/test.rb
+++ b/test.rb
@@ -19,9 +19,9 @@ def test_index(file, engine, *classes)
   classes.each do |klass|
     puts "========== #{klass} =========="
     puts "== Instance Methods =="
-    pp engine.fetch_class(klass).instance_method_objects(false)
+    pp engine.fetch_class(klass).instance_method_objects
     puts "== Class Methods =="
-    pp engine.fetch_class(klass).class_method_objects(false)
+    pp engine.fetch_class(klass).class_method_objects
   end
 end
 


### PR DESCRIPTION
# Summary
- Index module mixin
- Inheritance specs did not cover the case where a class's superclass is defined after itself which eventually causes the mixin test to be broken. Fix is added for inheritance and its dedicated test will be in turn updated in another PR

# Inheritance Problem
Initially, processor `getconstant` creates a new ClassObject and labels it as module for any constants that the processor is at that time unable to locate.

Now assume that the constant is a superclass that gets referred to when its body definition not yet processed, it will be first wrongly saved as a module. When its `defineclass` pops out, it will be skipped at `@engine.define_class` since its definition was already there to begin with. If it itself were to be inherited from another class, this information would be completely left out.

The same goes to module, but it is defined correctly from the start and further it does not matter its `defineclass` gets skipped because module definition does not include extra information other than than that how it is previously created.

# Changes
- Register new processors: `include`, `extend` and `prepend`
- Add three new containers to hold different types of mixin-ed modules and their according index functions
- Add test
- Update the implementation of `instance_method_objects` and `class_method_objects`
- Update the implementation of engine's `define_class`