### PR TITLE
Refactor VM

### DIFF
--- a/lib/ruby_zen.rb
+++ b/lib/ruby_zen.rb
@@ -1,13 +1,22 @@
 require 'yarv_generator'
 require 'ruby_zen/version'
+require 'ruby_zen/double_stack'
+
 require 'ruby_zen/indexers/class_indexer'
 require 'ruby_zen/indexers/iseq_indexer'
 require 'ruby_zen/indexers/ruby_core_indexer'
 
-require 'ruby_zen/double_stack'
 require 'ruby_zen/objects/class_object'
 require 'ruby_zen/objects/method_object'
 require 'ruby_zen/objects/return_object'
+
+require 'ruby_zen/interpreter_registry'
+require 'ruby_zen/interpreters/base'
+
+Dir[File.expand_path('../ruby_zen/interpreters/*_interpreter*.rb', __FILE__)].each do |file|
+  require file
+end
+
 require 'ruby_zen/vm'
 require 'ruby_zen/engine'
 

--- a/lib/ruby_zen/engine.rb
+++ b/lib/ruby_zen/engine.rb
@@ -19,9 +19,9 @@ module RubyZen
       @logger.info('RubyZen is ready!')
     end
 
-    def index_iseq(iseq)
+    def index_iseq(code)
       RubyZen::Indexers::IseqIndexer.new(
-        iseq,
+        code,
         engine: self,
         logger: @logger
       ).start

--- a/lib/ruby_zen/indexers/iseq_indexer.rb
+++ b/lib/ruby_zen/indexers/iseq_indexer.rb
@@ -2,167 +2,25 @@ module RubyZen::Indexers
   class IseqIndexer
     attr_reader :iseq
 
-    def initialize(iseq, engine:, logger:)
+    def initialize(
+      code, engine:, logger:,
+      interpreter_registry: RubyZen::InterpreterRegistry.instance
+    )
       @engine = engine
-      @iseq = iseq
+      @code = code
       @logger = logger
-      @vm = RubyZen::VM.new(logger: logger)
-      add_callbacks
+
+      @interpreter_registry = interpreter_registry.prepare(logger: logger)
+      @vm = RubyZen::VM.new(
+        engine: @engine,
+        logger: @logger,
+        interpreter_registry: @interpreter_registry
+      )
     end
 
     def start
+      iseq = YarvGenerator.build_from_source(@code)
       @vm.run(iseq)
-    end
-
-    def add_callbacks
-      @vm.on('defineclass') do |name, _body, superclass, cbase, flags|
-        name = "#{cbase.fullname}::#{name}" unless cbase.nil?
-        if (flags & 0x1) > 0
-          # Singleton class
-          cbase.singleton_class
-        elsif (flags & 0x2) > 0
-          # Module
-          @engine.define_class(name) do
-            RubyZen::ClassObject.new(
-              name, is_module: true, namespace: cbase
-            )
-          end
-        else
-          # Normal class
-          @engine.define_class(name) do
-            RubyZen::ClassObject.new(name, superclass: superclass, namespace: cbase)
-          end
-        end
-      end
-
-      @vm.on('getconstant') do |name, namespace|
-        name = "#{namespace.fullname}::#{name}" unless namespace.nil?
-        const = @engine.fetch_class(name)
-        if const.nil?
-          @engine.define_class(name) do
-            RubyZen::ClassObject.new(name, is_module: true)
-          end
-        else
-          const
-        end
-      end
-
-      @vm.on('opt_send_without_block', 'define_method') do |receiver, method_name, method_body|
-        define_instance_method(receiver, method_name, method_body)
-      end
-
-      @vm.on('opt_send_without_block', 'define_singleton_method') do |receiver, method_name, method_body|
-        define_class_method(receiver, method_name, method_body)
-      end
-
-      @vm.on('opt_send_without_block', 'instance_method') do |receiver, method_name|
-        receiver.instance_method_object(method_name)
-      end
-
-      @vm.on('opt_send_without_block', 'method') do |receiver, method_name|
-        receiver.class_method_object(method_name)
-      end
-
-      @vm.on('opt_send_without_block', 'include') do |receiver, module_definition|
-        receiver.include_module(module_definition)
-      end
-
-      @vm.on('opt_send_without_block', 'extend') do |receiver, module_definition|
-        receiver.extend_module(module_definition)
-      end
-
-      @vm.on('opt_send_without_block', 'prepend') do |receiver, module_definition|
-        receiver.prepend_module(module_definition)
-      end
-
-      @vm.on('send', 'define_method') do |receiver, method_name, method_body|
-        define_instance_method(receiver, method_name, method_body)
-      end
-
-      @vm.on('send', 'define_singleton_method') do |receiver, method_name, method_body|
-        define_class_method(receiver, method_name, method_body)
-      end
-    end
-
-    private
-
-    def define_instance_method(receiver, method_name, method_body, singleton: false)
-      if method_body.is_a?(RubyZen::MethodObject)
-        method_object = RubyZen::MethodObject.new(
-          method_name,
-          owner: receiver,
-          parameters: method_body.parameters,
-          super_method: method_body.super_method
-        )
-      else
-        method_object = create_method_object(method_name, method_body, owner: receiver)
-      end
-      receiver.add_method(method_object)
-
-      @logger.info("Detect instance method `#{method_name}` of class `#{receiver.to_s}`")
-    end
-
-    def define_class_method(receiver, method_name, method_body)
-      if method_body.is_a?(RubyZen::MethodObject)
-        method_object = RubyZen::MethodObject.new(
-          method_name,
-          owner: receiver.singleton_class,
-          parameters: method_body.parameters,
-          super_method: method_body.super_method
-        )
-      else
-        method_object = create_method_object(method_name, method_body, owner: receiver.singleton_class)
-      end
-      receiver.add_class_method(method_object)
-
-      @logger.info("Detect class method `#{method_name}` of class `#{receiver.to_s}`")
-    end
-
-    def create_method_object(method_name, method_body, owner: nil)
-      parameters = []
-
-      if method_body.params[:lead_num]
-        req_variables = method_body.local_table.first(method_body.params[:lead_num])
-        req_variables.map do |variable|
-          parameters << [:req, variable]
-        end
-      end
-
-      if method_body.params[:opt]
-        lead_num = method_body.params[:lead_num] || 0
-        method_body.params[:opt].each_with_index do |opt, index|
-          parameters << [:opt, method_body.local_table[lead_num + index], opt]
-        end
-      end
-
-      if method_body.params[:rest_start]
-        parameters << [
-          :rest,
-          method_body.local_table[method_body.params[:rest_start]]
-        ]
-      end
-
-      if method_body.params[:keywords]
-        method_body.params[:keywords].map do |variable|
-          parameters << if variable.is_a?(Array)
-                          [:key, variable[0], variable[1]]
-                        else
-                          [:keyreq, variable]
-                        end
-        end
-      end
-
-      if method_body.params[:kwrest]
-        parameters << [
-          :keyrest,
-          method_body.local_table[method_body.params[:kwrest]]
-        ]
-      end
-
-      RubyZen::MethodObject.new(
-        method_name,
-        parameters: parameters, owner: owner
-      )
     end
   end
 end

--- a/lib/ruby_zen/indexers/ruby_core_indexer.rb
+++ b/lib/ruby_zen/indexers/ruby_core_indexer.rb
@@ -125,17 +125,18 @@ module RubyZen::Indexers
     def index_return_value(method)
       return_objects = []
       return_value = []
+      method_name = method.name.to_s
 
-      if INSTANTIATION_METHODS.include?(method.name)
+      if INSTANTIATION_METHODS.include?(method_name)
         return_objects << method.owner
-      elsif SIZE_METHODS.include?(method.name)
+      elsif SIZE_METHODS.include?(method_name)
         return_objects << @engine.fetch_class('Integer')
-      elsif method.name.end_with?('?') || COMPARISON_METHODS.include?(method.name)
+      elsif method_name.end_with?('?') || COMPARISON_METHODS.include?(method_name)
         return_objects << @engine.fetch_class('TrueClass')
         return_objects << @engine.fetch_class('FalseClass')
-      elsif method.name == 'json_create'
+      elsif method_name == 'json_create'
         return_objects << method.owner
-      elsif method.name == 'as_json'
+      elsif method_name == 'as_json'
         return_objects << @engine.fetch_class('Hash')
       elsif method.call_seq
         if method.call_seq =~ /->/
@@ -166,15 +167,15 @@ module RubyZen::Indexers
           end
           return_objects += parse_return_value(method, return_value.flatten.uniq)
         elsif method.call_seq =~ /to_/
-          return_objects = parse_transform_method(method.name[/(?<=_).*/])
-        elsif method.name =~ /exit|abort/
+          return_objects = parse_transform_method(method_name[/(?<=_).*/])
+        elsif method_name =~ /exit|abort/
           return_objects << @engine.fetch_class('Object')
         else
           return_objects << @engine.fetch_class('Object')
         end
-      elsif method.name =~ /to_/
-        return_objects = parse_transform_method(method.name[/(?<=_).*/])
-      elsif method.name =~ /exit|abort/
+      elsif method_name =~ /to_/
+        return_objects = parse_transform_method(method_name[/(?<=_).*/])
+      elsif method_name =~ /exit|abort/
         return_objects << @engine.fetch_class('Object')
       else
         return_objects << @engine.fetch_class('Object')

--- a/lib/ruby_zen/interpreter_registry.rb
+++ b/lib/ruby_zen/interpreter_registry.rb
@@ -1,0 +1,62 @@
+module RubyZen
+  class InterpreterRegistry
+    attr_reader :pattern, :interpreter
+
+    def initialize(pattern, interpreter)
+      @pattern = pattern
+      @interpreter = interpreter
+    end
+  end
+
+  class InterpreterRegistry
+    def self.instance
+      @instance ||= self.new
+    end
+
+    def initialize(interpreters: {}, interpreter_matchers: [])
+      @interpreters = interpreters
+      @interpreter_matchers = interpreter_matchers
+    end
+
+    def prepare(logger:)
+      InterpreterRegistry.new(
+        interpreters: @interpreters.each_with_object({}) do |(key, value), registry|
+          registry[key] = value.new(logger: logger)
+        end,
+        interpreter_matchers: @interpreter_matchers.map do |matcher|
+          {
+            pattern: matcher.pattern,
+            interpreter: matcher.interpreter.newA(logger: logger)
+          }
+        end
+      )
+    end
+
+    def add(instruction, intercepter)
+      case instruction.class.name
+      when 'String', 'Symbol'
+        instruction_name = instruction.to_s
+        if @interpreters.key?(instruction_name)
+          raise "Interpreter for `#{instruction_name}` instruction already exists!"
+        else
+          @interpreters[instruction_name] = intercepter
+        end
+      when 'Regexp'
+        @interpreter_matchers << InterpreterMatcher.new(
+          pattern: instruction,
+          interpreter: interpreter
+        )
+      else
+        raise 'Invalid interpreter matching'
+      end
+    end
+
+    def interpreter_for(instruction)
+      return @interpreters[instruction] if @interpreters.key?(instruction)
+
+      @interpreter_matchers.find do |matcher|
+        instruction =~ matcher.pattern
+      end
+    end
+  end
+end

--- a/lib/ruby_zen/interpreters/base.rb
+++ b/lib/ruby_zen/interpreters/base.rb
@@ -1,0 +1,13 @@
+module RubyZen::Interpreters
+  class Base
+    def self.interpret(instruction)
+      RubyZen::InterpreterRegistry.instance.add(instruction, self)
+    end
+
+		attr_reader :logger
+
+    def initialize(logger:)
+      @logger = logger
+    end
+  end
+end

--- a/lib/ruby_zen/interpreters/basic_interpreters.rb
+++ b/lib/ruby_zen/interpreters/basic_interpreters.rb
@@ -1,0 +1,56 @@
+module RubyZen::Interpreters
+  class PopInterpreter < Base
+    def handle_pop(vm, _instruction)
+      vm.environment.pop
+    end
+  end
+
+  class PutObjectInterpreter < Base
+    interpret 'putobject'
+
+    def call(vm, instruction)
+      vm.environment.push(instruction.operands[0])
+    end
+  end
+
+  class PutIseqtInterpreter < Base
+    interpret 'putiseq'
+
+    def call(vm, instruction)
+      vm.environment.push(instruction.operands[0])
+    end
+  end
+
+  class PutNilInterpreter < Base
+    interpret 'putnil'
+
+    def call(vm, instruction)
+      vm.environment.push(nil)
+    end
+  end
+
+  class PutSelfInterpreter < Base
+    interpret 'putself'
+
+    def call(vm, instruction)
+      vm.environment.push(vm.scope.last)
+    end
+  end
+
+  class PutSpecialObjectInterpreter < Base
+    interpret 'putspecialobject'
+
+    def call(vm, instruction)
+      case instruction.operands[0]
+      when 1
+        vm.environment.push(vm.scope.first)
+      when 2
+        vm.environment.push(nil)
+      when 3
+        vm.environment.push(vm.scope.last)
+      else
+        vm.environment.push(nil)
+      end
+    end
+  end
+end

--- a/lib/ruby_zen/interpreters/define_class_interpreter.rb
+++ b/lib/ruby_zen/interpreters/define_class_interpreter.rb
@@ -1,0 +1,45 @@
+module RubyZen::Interpreters
+  class DefineClassInterpreter < Base
+    interpret 'defineclass'
+
+    def call(vm, instruction)
+      superclass = vm.environment.pop
+      cbase = vm.environment.pop
+
+      class_name, class_body, flags = instruction.operands
+      class_name = "#{cbase.fullname}::#{class_name}" unless cbase.nil?
+
+      class_value = create_class_object(vm, class_name, superclass, cbase, flags)
+
+      vm.environment.new_frame
+      vm.environment.push(class_value)
+      vm.scope.push(class_value)
+      vm.run(class_body)
+    end
+
+    private
+
+    def create_class_object(vm, class_name, superclass, cbase, flags)
+      if (flags & 0x1) > 0
+        # Singleton class
+        cbase.singleton_class
+      elsif (flags & 0x2) > 0
+        # Module
+        vm.engine.define_class(class_name) do
+          RubyZen::ClassObject.new(
+            class_name, is_module: true, namespace: cbase
+          )
+        end
+      else
+        # Normal class
+        vm.engine.define_class(class_name) do
+          RubyZen::ClassObject.new(
+            class_name,
+            superclass: superclass,
+            namespace: cbase
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_zen/interpreters/get_constant_interpreter.rb
+++ b/lib/ruby_zen/interpreters/get_constant_interpreter.rb
@@ -1,0 +1,19 @@
+module RubyZen::Interpreters
+  class GetConstantInterpreter < Base
+    interpret 'getconstant'
+
+    def call(vm, instruction)
+      namespace = vm.environment.pop
+      name = instruction.operands[0]
+      name = "#{namespace.fullname}::#{name}" unless namespace.nil?
+
+      constant_value =
+        vm.engine.fetch_class(name) ||
+        vm.engine.define_class(name) do
+          RubyZen::ClassObject.new(name, is_module: true)
+        end
+
+      vm.environment.push(constant_value)
+    end
+  end
+end

--- a/lib/ruby_zen/interpreters/inline_cache_interpreters.rb
+++ b/lib/ruby_zen/interpreters/inline_cache_interpreters.rb
@@ -1,0 +1,18 @@
+module RubyZen::Interpreters
+  class GetInlineCacheInterpreter < Base
+    interpret 'getinlinecache'
+
+    def call(vm, instruction)
+      vm.environment.push(nil)
+    end
+  end
+
+  class SetInlineCacheInterpreter < Base
+    interpret 'setinlinecache'
+
+    def call(vm, instruction)
+      val = vm.environment.pop
+      vm.environment.push(val)
+    end
+  end
+end

--- a/lib/ruby_zen/interpreters/leave_interpreter.rb
+++ b/lib/ruby_zen/interpreters/leave_interpreter.rb
@@ -1,0 +1,10 @@
+module RubyZen::Interpreters
+  class LeaveInterpreter < Base
+    interpret 'leave'
+
+    def call(vm, _instruction)
+      vm.environment.leave_frame
+      vm.scope.pop
+    end
+  end
+end

--- a/lib/ruby_zen/interpreters/opt_send_without_block_interpreter.rb
+++ b/lib/ruby_zen/interpreters/opt_send_without_block_interpreter.rb
@@ -1,0 +1,100 @@
+module RubyZen::Interpreters
+  class OptSendWithoutBlockInterpreter < Base
+    interpret 'opt_send_without_block'
+
+    def call(vm, instruction)
+      call_info, _call_cache = instruction.operands
+      case call_info.mid
+      when :"core#define_method", :define_method
+        handle_define_method(vm)
+      when :"core#define_singleton_method", :define_singleton_method
+        handle_define_singleton_method(vm)
+      when :instance_method
+        handle_instance_method(vm)
+      when :method
+        handle_method(vm)
+      when :include
+        handle_include(vm)
+      when :extend
+        handle_extend(vm)
+      when :prepend
+        handle_prepend(vm)
+      else
+        logger.debug("Method #{call_info.mid} not handled.")
+      end
+    end
+
+    private
+
+    def handle_define_method(vm)
+      receiver = vm.scope.last
+      method_body = vm.environment.pop
+      method_name = vm.environment.pop
+
+      method_object = vm.define_instance_method(receiver, method_name, method_body)
+
+      if method_body.is_a?(YarvGenerator::Iseq)
+        vm.environment.new_frame
+        vm.environment.push(method_object)
+        vm.scope.push(vm.scope.last)
+        vm.run(method_body)
+      end
+
+      vm.environment.push(method_object)
+    end
+
+    def handle_define_singleton_method(vm)
+      method_body = vm.environment.pop
+      method_name = vm.environment.pop
+      receiver = vm.environment.pop
+
+      method_object = vm.define_class_method(receiver, method_name, method_body)
+
+      if method_body.is_a?(YarvGenerator::Iseq)
+        vm.environment.new_frame
+        vm.environment.push(method_object)
+        vm.scope.push(vm.scope.last)
+        vm.run(method_body)
+      end
+
+      vm.environment.push(method_object)
+    end
+
+    def handle_instance_method(vm)
+      method_name = vm.environment.pop
+      receiver = vm.environment.pop
+
+      method_object = receiver.instance_method_object(method_name)
+      vm.environment.push(method_object)
+    end
+
+    def handle_method(vm)
+      method_name = vm.environment.pop
+      receiver = vm.environment.pop
+
+      method_object = receiver.class_method_object(method_name)
+      vm.environment.push(method_object)
+    end
+
+    def handle_include(vm)
+      module_definition = vm.environment.pop
+      receiver = vm.environment.pop
+
+      receiver.include_module(module_definition)
+    end
+
+    def handle_extend(vm)
+      module_definition = vm.environment.pop
+      receiver = vm.environment.pop
+
+      receiver.extend_module(module_definition)
+    end
+
+    def handle_prepend(vm)
+      module_definition = vm.environment.pop
+      receiver = vm.environment.pop
+
+      receiver.prepend_module(module_definition)
+    end
+  end
+end

--- a/lib/ruby_zen/interpreters/send_interpreter.rb
+++ b/lib/ruby_zen/interpreters/send_interpreter.rb
@@ -1,0 +1,47 @@
+module RubyZen::Interpreters
+  class SendInterpreter < Base
+    interpret 'send'
+
+    def call(vm, instruction)
+      call_info, _call_cache, block_iseq = instruction.operands
+      case call_info.mid
+      when :define_method
+        handle_define_method(vm, block_iseq)
+      when :define_singleton_method
+        handle_define_singleton_method(vm, block_iseq)
+      else
+        logger.debug("Method #{call_info.mid} not handled.")
+      end
+    end
+
+    private
+
+    def handle_define_method(vm, method_body)
+      method_name = vm.environment.pop
+      receiver = vm.environment.pop
+
+      method_object = vm.define_instance_method(receiver, method_name, method_body)
+
+      vm.environment.new_frame
+      vm.environment.push(method_object)
+      vm.scope.push(vm.scope.last)
+      vm.run(method_body)
+
+      vm.environment.push(method_object)
+    end
+
+    def handle_define_singleton_method(vm, method_body)
+      method_name = vm.environment.pop
+      receiver = vm.environment.pop
+
+      method_object = vm.define_class_method(receiver, method_name, method_body)
+
+      vm.environment.new_frame
+      vm.environment.push(method_object)
+      vm.scope.push(vm.scope.last)
+      vm.run(method_body)
+
+      vm.environment.push(method_object)
+    end
+  end
+end

--- a/lib/ruby_zen/objects/class_object.rb
+++ b/lib/ruby_zen/objects/class_object.rb
@@ -67,7 +67,11 @@ module RubyZen
     end
 
     def add_method(method_object)
-      @method_objects[method_object.name] = method_object
+      if @method_objects[method_object.name]
+        @method_objects[method_object.name].merge!(method_object)
+      else
+        @method_objects[method_object.name] = method_object
+      end
     end
 
     def add_class_method(method_object)

--- a/lib/ruby_zen/objects/method_object.rb
+++ b/lib/ruby_zen/objects/method_object.rb
@@ -4,7 +4,7 @@ module RubyZen
                   :call_seq, :c_function, :singleton, :param_list, :return_value
 
     def initialize(name, owner: nil, parameters: [], super_method: nil)
-      @name = name
+      @name = name.to_sym
       @owner = owner
       @parameters = parameters
       @super_method = super_method

--- a/lib/ruby_zen/objects/method_object.rb
+++ b/lib/ruby_zen/objects/method_object.rb
@@ -15,6 +15,17 @@ module RubyZen
       @return_object.add(object)
     end
 
+    def merge!(other)
+      @parameters = other.parameters unless other.parameters.empty?
+      unless other.return_object.empty?
+        if @return_object.empty?
+          @return_object = other.return_object
+        else
+          @return_object.add(other.return_object)
+        end
+      end
+    end
+
     def inpsect
       "#<MethodObject: #{name}, parameters: #{parameters.inspect}, owner: #{owner.nil? ? '<empty>' : owner.fullname}, super_method: #{super_method.nil? ? '<empty>' : super_method.inspect}>"
     end

--- a/lib/ruby_zen/objects/return_object.rb
+++ b/lib/ruby_zen/objects/return_object.rb
@@ -13,6 +13,10 @@ module RubyZen
       @possibilities.add(object)
     end
 
+    def empty?
+      @possibilities.empty?
+    end
+
     def to_set
       possibilities = Set.new
       @possibilities.each do |possibility|

--- a/lib/ruby_zen/vm.rb
+++ b/lib/ruby_zen/vm.rb
@@ -1,254 +1,110 @@
 module RubyZen
   class VM
-    def initialize(scope: nil, logger:)
-      @callbacks = {}
+    attr_reader :engine, :environment, :scope
+
+    def initialize(engine:, scope: nil, logger:, interpreter_registry:)
+      @engine = engine
+
+      @environment = RubyZen::DoubleStack.new
+      @scope = [scope]
 
       @logger = logger
-
-      @scope = [scope]
-      @stack = RubyZen::DoubleStack.new
+      @interpreter_registry = interpreter_registry
     end
 
     def run(iseq)
       @logger.info("Indexing iseq `#{iseq.label}`, type: `#{iseq.type}`, path: `#{iseq.path}`")
 
-      iseq.instructions.each_with_index do |instruction, index|
-        handler_name = "handle_#{instruction.name}".to_sym
-        if respond_to?(handler_name, true)
-          @logger.debug("Running instruction `#{instruction.name}` with params #{instruction.operands}")
-          send(handler_name, instruction)
-        else
+      iseq.instructions.each do |instruction|
+        interpreter = @interpreter_registry.interpreter_for(instruction.name)
+        if interpreter.nil?
           @logger.debug("Skip instruction `#{instruction.name}`")
-        end
-      end
-    end
-
-    def on(instruction_name, *filters, &callback)
-      @callbacks[instruction_name] ||= []
-      @callbacks[instruction_name] << {
-        proc: callback,
-        filters: filters
-      }
-    end
-
-    def dispatch_callback(instruction_name, filter: nil, args: [])
-      callback =
-        if !@callbacks[instruction_name]
-          nil
-        elsif filter.nil?
-          @callbacks[instruction_name].first
         else
-          @callbacks[instruction_name].find do |p|
-            p[:filters].include?(filter)
-          end
+          @logger.debug("Interpreting #{instruction.name}(#{instruction.operands})")
+          interpreter.call(self, instruction)
         end
-      callback[:proc].call(*args) if callback
-    end
-
-    private
-
-    def handle_putspecialobject(instruction)
-      case instruction.operands[0]
-      when 1
-        @stack.push(@scope.first)
-      when 2
-        @stack.push(nil)
-      when 3
-        @stack.push(@scope.last)
-      else
-        @stack.push(nil)
       end
     end
 
-    def handle_putobject(instruction)
-      @stack.push(instruction.operands[0])
+    def define_instance_method(receiver, method_name, method_body)
+      method_object =
+        if method_body.is_a?(RubyZen::MethodObject)
+          RubyZen::MethodObject.new(
+            method_name,
+            owner: receiver,
+            parameters: method_body.parameters,
+            super_method: method_body.super_method
+          )
+        else
+          create_method_object(method_name, method_body, owner: receiver)
+        end
+      receiver.add_method(method_object)
+
+      @logger.info("Detect instance method `#{method_name}` of class `#{receiver}`")
     end
 
-    def handle_putiseq(instruction)
-      @stack.push(instruction.operands[0])
+    def define_class_method(receiver, method_name, method_body)
+      method_object =
+        if method_body.is_a?(RubyZen::MethodObject)
+          RubyZen::MethodObject.new(
+            method_name,
+            owner: receiver.singleton_class,
+            parameters: method_body.parameters,
+            super_method: method_body.super_method
+          )
+        else
+          create_method_object(method_name, method_body, owner: receiver.singleton_class)
+        end
+      receiver.add_class_method(method_object)
+
+      @logger.info("Detect class method `#{method_name}` of class `#{receiver}`")
     end
 
-    def handle_putnil(_instruction)
-      @stack.push(nil)
-    end
+    def create_method_object(method_name, method_body, owner: nil)
+      parameters = []
 
-    def handle_putself(_instruction)
-      @stack.push(@scope.last)
-    end
+      if method_body.params[:lead_num]
+        req_variables = method_body.local_table.first(method_body.params[:lead_num])
+        req_variables.map do |variable|
+          parameters << [:req, variable]
+        end
+      end
 
-    def handle_pop(_instruction)
-      @stack.pop
-    end
+      if method_body.params[:opt]
+        lead_num = method_body.params[:lead_num] || 0
+        method_body.params[:opt].each_with_index do |opt, index|
+          parameters << [:opt, method_body.local_table[lead_num + index], opt]
+        end
+      end
 
-    def handle_getconstant(instruction)
-      name = instruction.operands[0]
-      klass = @stack.pop
-      constant_value = dispatch_callback(
-        instruction.name, args: [name, klass]
+      if method_body.params[:rest_start]
+        parameters << [
+          :rest,
+          method_body.local_table[method_body.params[:rest_start]]
+        ]
+      end
+
+      if method_body.params[:keywords]
+        method_body.params[:keywords].map do |variable|
+          parameters << if variable.is_a?(Array)
+                          [:key, variable[0], variable[1]]
+                        else
+                          [:keyreq, variable]
+                        end
+        end
+      end
+
+      if method_body.params[:kwrest]
+        parameters << [
+          :keyrest,
+          method_body.local_table[method_body.params[:kwrest]]
+        ]
+      end
+
+      RubyZen::MethodObject.new(
+        method_name,
+        parameters: parameters, owner: owner
       )
-      @stack.push(constant_value)
-    end
-
-    def handle_defineclass(instruction)
-      class_name, class_body, flags = instruction.operands
-      superclass = @stack.pop
-      cbase = @stack.pop
-
-      class_value = dispatch_callback(
-        instruction.name,
-        args: [class_name, class_body, superclass, cbase, flags]
-      )
-
-      @stack.new_frame
-      @stack.push(class_value)
-      @scope.push(class_value)
-      run(class_body)
-    end
-
-    def handle_opt_send_without_block(instruction)
-      call_info, _call_cache = instruction.operands
-      case call_info.mid
-      when :"core#define_method", :define_method
-        method_body = @stack.pop
-        method_name = @stack.pop
-
-        method_object = dispatch_callback(
-          instruction.name,
-          filter: 'define_method',
-          args: [@scope.last, method_name, method_body]
-        )
-
-        if method_body.is_a?(YarvGenerator::Iseq)
-          @stack.new_frame
-          @stack.push(method_object)
-          @scope.push(@scope)
-          run(method_body)
-        end
-
-        @stack.push(method_object)
-      when :"core#define_singleton_method", :define_singleton_method
-        method_body = @stack.pop
-        method_name = @stack.pop
-        receiver = @stack.pop
-
-        method_object = dispatch_callback(
-          instruction.name,
-          filter: 'define_singleton_method',
-          args: [receiver, method_name, method_body]
-        )
-
-        if method_body.is_a?(YarvGenerator::Iseq)
-          @stack.new_frame
-          @stack.push(method_object)
-          @scope.push(@scope)
-          run(method_body)
-        end
-
-        @stack.push(method_object)
-      when :instance_method
-        method_name = @stack.pop
-        receiver = @stack.pop
-
-        method_object = dispatch_callback(
-          instruction.name,
-          filter: 'instance_method',
-          args: [receiver, method_name]
-        )
-        @stack.push(method_object)
-      when :method
-        method_name = @stack.pop
-        receiver = @stack.pop
-
-        method_object = dispatch_callback(
-          instruction.name,
-          filter: 'method',
-          args: [receiver, method_name]
-        )
-        @stack.push(method_object)
-      when :include
-        module_definition = @stack.pop
-        receiver = @stack.pop
-
-        dispatch_callback(
-          instruction.name,
-          filter: 'include',
-          args: [receiver, module_definition]
-        )
-      when :extend
-        module_definition = @stack.pop
-        receiver = @stack.pop
-
-        dispatch_callback(
-          instruction.name,
-          filter: 'extend',
-          args: [receiver, module_definition]
-        )
-      when :prepend
-        module_definition = @stack.pop
-        receiver = @stack.pop
-
-        dispatch_callback(
-          instruction.name,
-          filter: 'prepend',
-          args: [receiver, module_definition]
-        )
-      else
-        @logger.debug("Method #{call_info.mid} not handled.")
-      end
-    end
-
-    def handle_send(instruction)
-      call_info, _call_cache, block_iseq = instruction.operands
-      case call_info.mid
-      when :define_method
-        method_name = @stack.pop
-        receiver = @stack.pop
-
-        method_object = dispatch_callback(
-          instruction.name,
-          filter: 'define_method',
-          args: [receiver, method_name, block_iseq]
-        )
-
-        @stack.new_frame
-        @stack.push(method_object)
-        @scope.push(@scope.last)
-        run(block_iseq)
-
-        @stack.push(method_object)
-      when :define_singleton_method
-        method_name = @stack.pop
-        receiver = @stack.pop
-
-        method_object = dispatch_callback(
-          instruction.name,
-          filter: 'define_singleton_method',
-          args: [receiver, method_name, block_iseq]
-        )
-
-        @stack.new_frame
-        @stack.push(method_object)
-        @scope.push(@scope.last)
-        run(block_iseq)
-
-        @stack.push(method_object)
-      else
-        @logger.debug("Method #{call_info.mid} not handled.")
-      end
-    end
-
-    def handle_leave(_instruction)
-      @stack.leave_frame
-      @scope.pop
-    end
-
-    def handle_getinlinecache(_instruction)
-      @stack.push(nil)
-    end
-
-    def handle_setinlinecache(_instruction)
-      val = @stack.pop
-      @stack.push(val)
     end
   end
 end

--- a/spec/medium/definitions/inheritance_spec.rb
+++ b/spec/medium/definitions/inheritance_spec.rb
@@ -92,10 +92,9 @@ RSpec.describe 'index class with the involvement of inheritance' do
   end
 
   let(:engine) { RubyZen::Engine.new(logger: TestingLogger.new(STDOUT)) }
-  let(:iseq) { YarvGenerator.build_from_source(code) }
 
   before do
-    engine.index_iseq(iseq)
+    engine.index_iseq(code)
   end
 
   context 'index' do

--- a/spec/medium/definitions/mixin_spec.rb
+++ b/spec/medium/definitions/mixin_spec.rb
@@ -6,10 +6,9 @@ RSpec.describe 'index mixin-ed class' do
   let(:module_2) { 'SecondModule' }
 
   let(:engine) { RubyZen::Engine.new(logger: TestingLogger.new(STDOUT)) }
-  let(:iseq) { YarvGenerator.build_from_source(code) }
 
   before do
-    engine.index_iseq(iseq)
+    engine.index_iseq(code)
   end
 
   context 'include' do

--- a/spec/medium/definitions/module_spec.rb
+++ b/spec/medium/definitions/module_spec.rb
@@ -2,10 +2,9 @@ require 'spec_helper'
 
 RSpec.describe 'index module' do
   let(:engine) { RubyZen::Engine.new(logger: TestingLogger.new(STDOUT)) }
-  let(:iseq) { YarvGenerator.build_from_source(code) }
 
   before do
-    engine.index_iseq(iseq)
+    engine.index_iseq(code)
   end
 
   context 'class methods' do

--- a/spec/medium/methods/class_method_spec.rb
+++ b/spec/medium/methods/class_method_spec.rb
@@ -40,10 +40,9 @@ RSpec.describe 'index class methods' do
   end
 
   let(:engine) { RubyZen::Engine.new(logger: TestingLogger.new(STDOUT)) }
-  let(:iseq) { YarvGenerator.build_from_source(code) }
 
   before do
-    engine.index_iseq(iseq)
+    engine.index_iseq(code)
   end
 
   it 'supports "self.method" syntax' do

--- a/spec/medium/methods/instance_method_spec.rb
+++ b/spec/medium/methods/instance_method_spec.rb
@@ -59,10 +59,9 @@ RSpec.describe 'index instance methods' do
   end
 
   let(:engine) { RubyZen::Engine.new(logger: TestingLogger.new(STDOUT)) }
-  let(:iseq) { YarvGenerator.build_from_source(code) }
 
   before do
-    engine.index_iseq(iseq)
+    engine.index_iseq(code)
   end
 
   it 'supports normal method arguments' do

--- a/spec/medium/methods/instance_method_with_namespace_spec.rb
+++ b/spec/medium/methods/instance_method_with_namespace_spec.rb
@@ -30,10 +30,9 @@ RSpec.describe 'index instance methods' do
   end
 
   let(:engine) { RubyZen::Engine.new(logger: TestingLogger.new(STDOUT)) }
-  let(:iseq) { YarvGenerator.build_from_source(code) }
 
   before do
-    engine.index_iseq(iseq)
+    engine.index_iseq(code)
   end
 
   it 'supports nested module syntax' do

--- a/spec/medium/methods/internal_method_spec.rb
+++ b/spec/medium/methods/internal_method_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'index internal ruby' do
 
     context 'constructor' do
       it 'sets return object to owner of method' do
-        method = array.class_method_object('new')
+        method = array.class_method_object(:new)
         return_object = method.return_object.to_set
 
         expect(method.owner).to be(array)
@@ -51,7 +51,7 @@ RSpec.describe 'index internal ruby' do
 
     context 'size' do
       it 'sets return object to Integer class' do
-        method = array.instance_method_object('length')
+        method = array.instance_method_object(:length)
         return_object = method.return_object.to_set
 
         expect(method.owner).to be(array)
@@ -62,7 +62,7 @@ RSpec.describe 'index internal ruby' do
 
     context 'method ends with ?' do
       it 'sets possbile return objects to TrueClass and FalseClass' do
-        method = array.instance_method_object('is_nil?')
+        method = array.instance_method_object(:is_nil?)
         return_object = method.return_object.to_set
 
         expect(method.owner).to be(array)
@@ -74,8 +74,8 @@ RSpec.describe 'index internal ruby' do
 
     context 'aliased method' do
       it 'clones originial method and changes name' do
-        original_method = array.instance_method_object('inspect')
-        method = array.instance_method_object('to_s')
+        original_method = array.instance_method_object(:inspect)
+        method = array.instance_method_object(:to_s)
         return_object = method.return_object.to_set
 
         expect(method.owner).to be(original_method.owner)
@@ -88,7 +88,7 @@ RSpec.describe 'index internal ruby' do
 
     context 'call-seq is given in format ->' do
       it 'parses return objects correctly' do
-        method = array.class_method_object('dup')
+        method = array.class_method_object(:dup)
         return_object = method.return_object.to_set
 
         expect(method.owner).to be(array)
@@ -101,7 +101,7 @@ RSpec.describe 'index internal ruby' do
 
     context 'call-seq is given in format =>' do
       it 'parses return objects correctly' do
-        method = array.class_method_object('try_convert')
+        method = array.class_method_object(:try_convert)
         return_object = method.return_object.to_set
 
         expect(method.owner).to be(array)
@@ -116,7 +116,7 @@ RSpec.describe 'index internal ruby' do
 
     context 'call-seq is given in format =' do
       it 'parses return objects correctly' do
-        method = array.instance_method_object('freeze')
+        method = array.instance_method_object(:freeze)
         return_object = method.return_object.to_set
 
         expect(method.owner).to be(array)
@@ -130,7 +130,7 @@ RSpec.describe 'index internal ruby' do
     context 'call-seq is given but contains no actual information' do
       context 'method is of format to_' do
         it 'parses return objects correctly' do
-          method = array.instance_method_object('to_a')
+          method = array.instance_method_object(:to_a)
           return_object = method.return_object.to_set
 
           expect(method.owner).to be(array)
@@ -141,7 +141,7 @@ RSpec.describe 'index internal ruby' do
 
       context 'normal method' do
         it 'sets return object to Object class' do
-          method = array.class_method_object('abort')
+          method = array.class_method_object(:abort)
           return_object = method.return_object.to_set
 
           expect(method.owner).to be(array)
@@ -154,7 +154,7 @@ RSpec.describe 'index internal ruby' do
     context 'call-seq is not given' do
       context 'method is of format to_' do
         it 'parses return objects correctly' do
-          method = array.instance_method_object('to_f')
+          method = array.instance_method_object(:to_f)
           return_object = method.return_object.to_set
 
           expect(method.owner).to be(array)
@@ -165,7 +165,7 @@ RSpec.describe 'index internal ruby' do
 
       context 'normal method' do
         it 'sets return object to Object class' do
-          method = array.instance_method_object('exit')
+          method = array.instance_method_object(:exit)
           return_object = method.return_object.to_set
 
           expect(method.owner).to be(array)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,8 @@
 require "bundler/setup"
-require "ruby_zen"
 require 'byebug'
 require 'rspec'
 require 'logger'
+require 'ruby_zen'
 
 class TestingLogger
   def initialize(output)


### PR DESCRIPTION
- Merge VM and iseq indexer into one. Now VM can access the Engine
- Refactor the structure of VM. Move all the iseq handlers out to become Interpreters. Each interpreter class handles a specific instruction. This allows better expansion, isolation, testing, etc.